### PR TITLE
Add boolean to access the drawData ( available only between Render() and NewFrame() )  

### DIFF
--- a/include/CinderImGui.h
+++ b/include/CinderImGui.h
@@ -161,7 +161,7 @@ void    initialize( const Options &options = Options() );
 void    connectWindow( ci::app::WindowRef window );
 //! disconnects window signals from imgui
 void    disconnectWindow( ci::app::WindowRef window );
-    
+
 // Cinder Helpers
 void Image( const ci::gl::Texture2dRef &texture, const ImVec2& size, const ImVec2& uv0 = ImVec2(0,1), const ImVec2& uv1 = ImVec2(1,0), const ImVec4& tint_col = ImVec4(1,1,1,1), const ImVec4& border_col = ImVec4(0,0,0,0) );
 bool ImageButton( const ci::gl::Texture2dRef &texture, const ImVec2& size, const ImVec2& uv0 = ImVec2(0,1),  const ImVec2& uv1 = ImVec2(1,0), int frame_padding = -1, const ImVec4& bg_col = ImVec4(0,0,0,1), const ImVec4& tint_col = ImVec4(1,1,1,1) );

--- a/include/CinderImGui.h
+++ b/include/CinderImGui.h
@@ -131,7 +131,9 @@ struct Options {
 	Options& antiAliasedLines( bool antiAliasing );
 	//! Enable anti-aliasing on filled shapes (rounded rectangles, circles, etc.)
 	Options& AntiAliasedShapes( bool antiAliasing );
-	
+	//! newFrame() call is handled in the main app (in case of accessing drawData between render() and newFrame() for instance)
+	Options& NewFrameInMainApp(bool newFrameInMainApp);
+
     //! sets imgui original theme
     Options& defaultTheme();
     //! sets the dark theme
@@ -145,9 +147,9 @@ struct Options {
     const std::vector<std::pair<ci::fs::path,float>>&   getFonts() const { return mFonts; }
     //! returns the glyph ranges if available for this font
     const ImWchar*                                      getFontGlyphRanges( const std::string &name ) const;
-    //! returns the window that will be use to connect the signals and render ImGui
-    const ImGuiStyle&                                   getStyle() const { return mStyle; }
-    
+	//! returns the window that will be use to connect the signals and render ImGui
+	const ImGuiStyle&                                   getStyle() const { return mStyle; }
+
 protected:
     ImGuiStyle                                  mStyle;
     std::vector<std::pair<ci::fs::path,float>>  mFonts;

--- a/src/CinderImGui.cpp
+++ b/src/CinderImGui.cpp
@@ -554,7 +554,7 @@ public:
     void initGlslProg();
     
     ImFont* getFont( const std::string &name );
-    
+
 protected:
     ci::gl::Texture2dRef    mFontTexture;
 	ci::gl::VaoRef          mVao;
@@ -565,14 +565,13 @@ protected:
     map<string,ImFont*>     mFonts;
 };
 
-
-
 Renderer::Renderer()
 {
     initGlslProg();
     initBuffers();
 }
 
+ 
 //! renders imgui drawlist
 void Renderer::render( ImDrawData* draw_data )
 {
@@ -592,7 +591,7 @@ void Renderer::render( ImDrawData* draw_data )
 	
 	shader->uniform( "uModelViewProjection", mat );
 	shader->uniform( "uTex", 0 );
-	
+
 	for (int n = 0; n < draw_data->CmdListsCount; n++) {
 		const ImDrawList* cmd_list = draw_data->CmdLists[n];
 		const ImDrawIdx* idx_buffer = &cmd_list->IdxBuffer.front();
@@ -1143,7 +1142,10 @@ namespace {
 		
 		ImGui::Render();
 		sNewFrame                   = false;
-		App::get()->dispatchAsync( [](){ ImGui::NewFrame(); sNewFrame = true; } );
+		App::get()->dispatchAsync( [](){ 
+			//ImGui::NewFrame(); 
+			sNewFrame = true; 
+		} );
 	}
 
 	void newFrameGuard()
@@ -1179,7 +1181,7 @@ void disconnectWindow( ci::app::WindowRef window )
         connection.disconnect();
     }
 }
-	
+
 ScopedWindow::ScopedWindow( const std::string &name, ImGuiWindowFlags flags)
 {
 	ImGui::Begin( name.c_str(), nullptr, flags );

--- a/src/CinderImGui.cpp
+++ b/src/CinderImGui.cpp
@@ -49,6 +49,7 @@ namespace ImGui {
 
 // static variables
 static bool sInitialized = false;
+static bool mNewFrameInMainApp = false;
 
 	
 ImGui::Options::Options()
@@ -189,7 +190,12 @@ ImGui::Options& ImGui::Options::AntiAliasedShapes( bool antiAliasing )
 	mStyle.AntiAliasedShapes = antiAliasing;
 	return *this;
 }
-	
+ImGui::Options& ImGui::Options::NewFrameInMainApp( bool newFrameInMainApp )
+{
+	mNewFrameInMainApp = newFrameInMainApp;
+	return *this;
+}
+
 const ImWchar* ImGui::Options::getFontGlyphRanges( const std::string &name ) const
 {
     if( mFontsGlyphRanges.count( name ) )
@@ -946,7 +952,7 @@ void initialize( const Options &options )
 		auto renderer = getRenderer();
 		renderer->render( data );
 	};
-	
+
 	// connect window's signals
 	connectWindow( window );
 	ImGui::NewFrame();
@@ -1142,8 +1148,11 @@ namespace {
 		
 		ImGui::Render();
 		sNewFrame                   = false;
-		App::get()->dispatchAsync( [](){ 
-			//ImGui::NewFrame(); 
+		App::get()->dispatchAsync([](){
+
+			if (!mNewFrameInMainApp) {
+				ImGui::NewFrame();
+			}
 			sNewFrame = true; 
 		} );
 	}


### PR DESCRIPTION
Added a mNewFrameInMainApp boolean to permit calling NewFrame() in the main app, not in CinderImGui, which permits to have access to the drawData ( available only between Render() and NewFrame() )  
To use it:
ui::initialize(ui::Options().NewFrameInMainApp(true));
It's false by default, so no problem with existing code using CinderImGui