### PR TITLE
Fix possible mouseUp and render race condition

### DIFF
--- a/src/CinderImGui.cpp
+++ b/src/CinderImGui.cpp
@@ -717,19 +717,22 @@ bool Combo( const char* label, int* current_item, const std::vector<std::string>
 }
 
 namespace {
-	
+
+	bool mousePressed[2] = { false, false };
+	bool mouseState[2]   = { false, false };
+
 	//! sets the right mouseDown IO values in imgui
 	void mouseDown( ci::app::MouseEvent& event )
 	{
 		ImGuiIO& io = ImGui::GetIO();
 		io.MousePos = toPixels( event.getPos() );
 		if( event.isLeftDown() ){
-			io.MouseDown[0] = true;
-			io.MouseDown[1] = false;
+			mousePressed[0] = true;
+			mouseState[0]   = true;
 		}
 		else if( event.isRightDown() ){
-			io.MouseDown[0] = false;
-			io.MouseDown[1] = true;
+			mousePressed[1] = true;
+			mouseState[1]   = true;
 		}
 		
 		event.setHandled( io.WantCaptureMouse );
@@ -753,9 +756,9 @@ namespace {
 	//! sets the right mouseDrag IO values in imgui
 	void mouseUp( ci::app::MouseEvent& event )
 	{
-		ImGuiIO& io     = ImGui::GetIO();
-		io.MouseDown[0] = false;
-		io.MouseDown[1] = false;
+		ImGuiIO& io   = ImGui::GetIO();
+        mouseState[0] = false;
+		mouseState[1] = false;
 		
 		event.setHandled( io.WantCaptureMouse );
 	}
@@ -827,6 +830,11 @@ namespace {
 		ImGuiIO& io = ImGui::GetIO();
 		io.DeltaTime = timer.getSeconds();
 		timer.start();
+
+		for ( int i = 0; i < IM_ARRAYSIZE(mousePressed); i++ ) {
+			io.MouseDown[i] = mousePressed[i] || mouseState[i];
+			mousePressed[i] = false;
+		}
 		
 		ImGui::Render();
 		sNewFrame = false;

--- a/src/CinderImGui.cpp
+++ b/src/CinderImGui.cpp
@@ -757,7 +757,7 @@ namespace {
 	void mouseUp( ci::app::MouseEvent& event )
 	{
 		ImGuiIO& io   = ImGui::GetIO();
-        mouseState[0] = false;
+		mouseState[0] = false;
 		mouseState[1] = false;
 		
 		event.setHandled( io.WantCaptureMouse );


### PR DESCRIPTION
When clicking, sometime the `mouseDown` and `mouseUp` event will come at a same frame, thus canceling the click action.  This is a fix for these situations, which it is a similar approach to the [imgui example](https://github.com/ocornut/imgui/blob/master/examples/opengl2_example/imgui_impl_glfw.cpp#L279)