### PR TITLE
not sure why this was breaking, but this fixed it

### DIFF
--- a/src/CinderImGui.cpp
+++ b/src/CinderImGui.cpp
@@ -402,7 +402,7 @@ void Renderer::render( ImDrawData* draw_data )
 			else {
 				gl::ScopedVao scopedVao( getVao().get() );
 				gl::ScopedBuffer scopedIndexBuffer( mIbo );
-				gl::ScopedGlslProg scopedShader( getGlslProg() );
+				gl::ScopedGlslProg scopedShader( shader );
 				gl::ScopedTextureBind scopedTexture( GL_TEXTURE_2D, (GLuint)(intptr_t) pcmd->TextureId );
 				gl::ScopedScissor scopedScissors( (int)pcmd->ClipRect.x, (int)(height - pcmd->ClipRect.w), (int)(pcmd->ClipRect.z - pcmd->ClipRect.x), (int)(pcmd->ClipRect.w - pcmd->ClipRect.y) );
 				gl::ScopedDepth scopedDepth( false );


### PR DESCRIPTION
… and it's probably more correct anyway. Compiler error was something about the function being deleted.

This was VS2015 Update 3 (v140, Windows 10 SDK)