### PR TITLE
fix issue with failing assertion if deltatime < 0

### DIFF
--- a/src/CinderImGui.cpp
+++ b/src/CinderImGui.cpp
@@ -885,6 +885,13 @@ namespace {
 		static auto timer = ci::Timer(true);
 		ImGuiIO& io = ImGui::GetIO();
 		io.DeltaTime = timer.getSeconds();
+
+		if (io.DeltaTime < 0.0f)
+		{
+			CI_LOG_W("WARNING: overriding imgui deltatime because it is " << io.DeltaTime);
+			io.DeltaTime = 1.0f/60.0f;
+		}
+
 		timer.start();
 		
 		ImGui::Render();


### PR DESCRIPTION
this should fix #37 by overriding the deltatime provided to imgui in CinderImGui