### PR TITLE
ColorPicker3: hide anything after '##' in label

### DIFF
--- a/src/CinderImGui.cpp
+++ b/src/CinderImGui.cpp
@@ -1464,9 +1464,15 @@ namespace {
 bool ColorPicker3( const char* label, float col[3] )
 {
 	ui::PushID( label );
-    bool changed = ColorPickerImpl( &col[0], false );
-	SameLine();
-	TextUnformatted( label );
+	bool changed = ColorPickerImpl( &col[0], false );
+	
+	// Hide anything after '##' in label
+	const char* text_display_end = FindRenderedTextEnd(label);
+	if (text_display_end - label > 0)
+	{
+		SameLine();
+		TextUnformatted( label, text_display_end );
+	}
 	ui::PopID();
 	return changed;
 }


### PR DESCRIPTION
- support ImGui's "##" approach to hide label but specify an ID.

This can be useful if (for example) you want to place your own labels above, below, or to the left of the ColorPicker, something not supported by ImGui.  Previously, if you used "##bgColor" as a ColorPicker3 label, you would see this full text to the right of the ColorPicker (unlike with other ImGui widgets)!  And, if you left the labels empty ("") and had several ColorPickers in the same window, they'd all be sharing the same ID...not very useful.
