### PR TITLE
Mac OSX project and resize fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,11 @@ project.xcworkspace
 xcuserdata/
 *.xccheckout
 .DS_Store
-
 build//
+[Bb]uild/
+[Oo]bj/
+*.o
+DerivedData/
 
 # Windows cruft
 *.suo

--- a/samples/Basic/xcode/Basic.xcodeproj/project.pbxproj
+++ b/samples/Basic/xcode/Basic.xcodeproj/project.pbxproj
@@ -39,10 +39,10 @@
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		191F7225241A4D008B19D0B8 /* BasicApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = BasicApp.cpp; path = ../src/BasicApp.cpp; sourceTree = "<group>"; };
 		1BFA2345D72E42838FFDE24C /* Basic_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = Basic_Prefix.pch; sourceTree = "<group>"; };
+		20496D9720D01E3B0094438F /* CinderImGuiExports.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CinderImGuiExports.h; path = ../../../include/CinderImGuiExports.h; sourceTree = "<group>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		34D47A91AC4741568117ADF1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		40DE7C313FA244EEA86CB0A6 /* imgui_user.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = imgui_user.h; path = ../../../include/imgui_user.h; sourceTree = "<group>"; };
 		42C59536675A423CAFB03803 /* CinderImGui.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CinderImGui.h; path = ../../../include/CinderImGui.h; sourceTree = "<group>"; };
 		4B02AFBC1B8B5EC2004AF2E2 /* imconfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = imconfig.h; path = ../../../lib/imgui/imconfig.h; sourceTree = "<group>"; };
 		4B02AFBD1B8B5EC2004AF2E2 /* imgui_draw.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = imgui_draw.cpp; path = ../../../lib/imgui/imgui_draw.cpp; sourceTree = "<group>"; };
@@ -54,7 +54,6 @@
 		D1CA960D32744D4AAEEF7623 /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Resources.h; path = ../include/Resources.h; sourceTree = "<group>"; };
 		DFE937C7594E4CE19F18B442 /* imgui.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = imgui.cpp; path = ../../../lib/imgui/imgui.cpp; sourceTree = "<group>"; };
 		F1C0117117214B579D5FA5E6 /* CinderImGui.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = CinderImGui.cpp; path = ../../../src/CinderImGui.cpp; sourceTree = "<group>"; };
-		F310282B4BFB49E29AF4EFA9 /* imgui_user.inl */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = imgui_user.inl; path = ../../../include/imgui_user.inl; sourceTree = "<group>"; };
 		F6B0A2037B314B59B623C416 /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = CinderApp.icns; path = ../resources/CinderApp.icns; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -206,8 +205,7 @@
 			isa = PBXGroup;
 			children = (
 				42C59536675A423CAFB03803 /* CinderImGui.h */,
-				40DE7C313FA244EEA86CB0A6 /* imgui_user.h */,
-				F310282B4BFB49E29AF4EFA9 /* imgui_user.inl */,
+				20496D9720D01E3B0094438F /* CinderImGuiExports.h */,
 			);
 			name = include;
 			sourceTree = "<group>";
@@ -297,7 +295,6 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CINDER_PATH = ../../../../../;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
@@ -313,7 +310,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
-				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder_d.a\"";
+				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/macosx/$(CONFIGURATION)/libcinder.a\"";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.libcinder.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Basic;
 				SYMROOT = ./build;
@@ -324,7 +321,6 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CINDER_PATH = ../../../../../;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -341,7 +337,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
-				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder.a\"";
+				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/macosx/$(CONFIGURATION)/libcinder.a\"";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.libcinder.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Basic;
 				STRIP_INSTALLED_PRODUCT = YES;
@@ -354,7 +350,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CINDER_PATH = ../../../../../cinder_fork;
+				CINDER_PATH = ../../../../..;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				CLANG_CXX_LIBRARY = "libc++";
 				ENABLE_TESTABILITY = YES;
@@ -372,7 +368,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CINDER_PATH = ../../../../../cinder_fork;
+				CINDER_PATH = ../../../../..;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				CLANG_CXX_LIBRARY = "libc++";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;

--- a/src/CinderImGui.cpp
+++ b/src/CinderImGui.cpp
@@ -1072,7 +1072,7 @@ void initialize( const Options &options )
 	connectWindow( window );
 	
 	if( options.isAutoRenderEnabled() && window ) {
-		App::get()->getSignalUpdate().connect( newFrameGuard );
+		window->getSignalDraw().connect( newFrameGuard );
 		sWindowConnections += ( window->getSignalPostDraw().connect( render ) );
 	}
 	


### PR DESCRIPTION
Calling `newFrameGuard` on the draw signal of the window, instead of on the app update signal, fixes  #18 and #60 and prevents the library from crashing on Mac OS.

It also allows ImGui to work on apps with multiple windows. The only drawback is that, when resizing, the UI drawn in `update()` will flicker (in Windows it disappears anyway). So I'd recommend updating the samples to have all the ui in `draw()`.
