### PR TITLE
This fixes a potential crash on cleanup().

### DIFF
--- a/src/CinderImGui.cpp
+++ b/src/CinderImGui.cpp
@@ -967,6 +967,9 @@ namespace {
 // wrong... and would not work in a multi-windows scenario
 static signals::ConnectionList sWindowConnections;
 
+// also wrong... but fixes a crash on cleanup
+static signals::ConnectionList sAppConnections;
+
 void initialize( const Options &options )
 {
 	// create one context for now. will update with multiple context / shared fontatlas soon!
@@ -1077,9 +1080,11 @@ void initialize( const Options &options )
 	}
 	
 	// connect app's signals
-	app::App::get()->getSignalDidBecomeActive().connect( resetKeys );
-	app::App::get()->getSignalWillResignActive().connect( resetKeys );
-	app::App::get()->getSignalCleanup().connect( [context](){
+    sAppConnections += app::App::get()->getSignalDidBecomeActive().connect( resetKeys );
+    sAppConnections += app::App::get()->getSignalWillResignActive().connect( resetKeys );
+    sAppConnections += app::App::get()->getSignalCleanup().connect( [context](){
+        sAppConnections.clear();
+
 		ImGui::DestroyContext( context );
 #if defined( IMGUI_DOCK )
 		ShutdownDock();


### PR DESCRIPTION
Sometimes when quitting the application, it crashed on a call to `resetKeys()`. After this patch, it no longer crashed.