### PR TITLE
Allow multiple ranges of font glyphs

### DIFF
--- a/src/CinderImGui.cpp
+++ b/src/CinderImGui.cpp
@@ -545,8 +545,8 @@ ImFont* Renderer::addFont( const ci::fs::path &font, float size, const ImWchar* 
 		for( const ImWchar* range = glyph_ranges; range[0] && range[1]; range += 2 ) {
 			ranges.push_back( range[0] );
 			ranges.push_back( range[1] );
-			ranges.push_back( 0 );
 		}
+		ranges.push_back( 0 );
 		glyphRanges = ranges.data();
 	}
 	// otherwise get them from the font


### PR DESCRIPTION
- fix bug in Renderer::addFont() when defining several glyph ranges
  for a font. The zero entry should only appear once, at the end,
  after all the range pairs, not after each one.

This is to fix issue #69.
