### PR TITLE
Update to imgui release v1.66

### DIFF
--- a/proj/cmake/Cinder-ImGuiConfig.cmake
+++ b/proj/cmake/Cinder-ImGuiConfig.cmake
@@ -5,6 +5,7 @@ if( NOT TARGET Cinder-ImGui )
 	${IMGUI_ROOT_PATH}/src/CinderImGui.cpp
 	${IMGUI_ROOT_PATH}/lib/imgui/imgui.cpp
 	${IMGUI_ROOT_PATH}/lib/imgui/imgui_draw.cpp
+	${IMGUI_ROOT_PATH}/lib/imgui/imgui_widgets.cpp
 	)
 
   add_library( Cinder-ImGui ${IMGUI_SOURCES} )

--- a/proj/vc2015/Cinder-ImGui.vcxproj
+++ b/proj/vc2015/Cinder-ImGui.vcxproj
@@ -331,6 +331,7 @@
     <ClCompile Include="..\..\lib\imgui\imgui.cpp" />
     <ClCompile Include="..\..\lib\imgui\imgui_demo.cpp" />
     <ClCompile Include="..\..\lib\imgui\imgui_draw.cpp" />
+    <ClCompile Include="..\..\lib\imgui\imgui_widgets.cpp" />
     <ClCompile Include="..\..\src\CinderImGui.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/proj/vc2015/Cinder-ImGui.vcxproj.filters
+++ b/proj/vc2015/Cinder-ImGui.vcxproj.filters
@@ -47,5 +47,8 @@
     <ClCompile Include="..\..\lib\imgui\imgui_demo.cpp">
       <Filter>Source Files\ImGui</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\lib\imgui\imgui_widgets.cpp">
+      <Filter>Source Files\ImGui</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/samples/Basic/vc2015/Basic.vcxproj
+++ b/samples/Basic/vc2015/Basic.vcxproj
@@ -191,6 +191,7 @@
   <ItemGroup />
   <ItemGroup />
   <ItemGroup>
+    <ClCompile Include="..\..\..\lib\imgui\imgui_widgets.cpp" />
     <ClCompile Include="..\src\BasicApp.cpp" />
     <ClCompile Include="..\..\..\src\CinderImGui.cpp" />
     <ClCompile Include="..\..\..\lib\imgui\imgui.cpp" />

--- a/samples/Basic/vc2015/Basic.vcxproj.filters
+++ b/samples/Basic/vc2015/Basic.vcxproj.filters
@@ -71,6 +71,9 @@
     <ClCompile Include="..\..\..\lib\imgui\imgui_demo.cpp">
       <Filter>Blocks\ImGui\lib\imgui</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\lib\imgui\imgui_widgets.cpp">
+      <Filter>Blocks\ImGui\lib\imgui</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\Resources.h">

--- a/src/CinderImGui.cpp
+++ b/src/CinderImGui.cpp
@@ -281,9 +281,6 @@ ImGui::Options& ImGui::Options::darkTheme()
 	style.Colors[ImGuiCol_ResizeGrip]            = ImVec4(0.47f, 0.77f, 0.83f, 0.04f);
 	style.Colors[ImGuiCol_ResizeGripHovered]     = ImVec4(0.92f, 0.18f, 0.29f, 0.78f);
 	style.Colors[ImGuiCol_ResizeGripActive]      = ImVec4(0.92f, 0.18f, 0.29f, 1.00f);
-	style.Colors[ImGuiCol_CloseButton]           = ImVec4(0.86f, 0.93f, 0.89f, 0.16f);
-	style.Colors[ImGuiCol_CloseButtonHovered]    = ImVec4(0.86f, 0.93f, 0.89f, 0.39f);
-	style.Colors[ImGuiCol_CloseButtonActive]     = ImVec4(0.86f, 0.93f, 0.89f, 1.00f);
 	style.Colors[ImGuiCol_PlotLines]             = ImVec4(0.86f, 0.93f, 0.89f, 0.63f);
 	style.Colors[ImGuiCol_PlotLinesHovered]      = ImVec4(0.92f, 0.18f, 0.29f, 1.00f);
 	style.Colors[ImGuiCol_PlotHistogram]         = ImVec4(0.86f, 0.93f, 0.89f, 0.63f);


### PR DESCRIPTION
This updates the imgui submodule to v1.66, commit https://github.com/ocornut/imgui/commit/da3c4330c1c3822cdc59b0c38c7e3c16aa3ef78a. Only two necessary changes were adding imgui_widgets.cpp file to the projects (I did this for the Visual Studio and cmake build configs), and then removing some no-longer present style flags.